### PR TITLE
`mq-recv` mutates queue data

### DIFF
--- a/posix-mq.scm
+++ b/posix-mq.scm
@@ -202,22 +202,61 @@ C_word chicken_mq_send(char *name, C_word oflags, C_word message, int priority, 
 #endif
     C_return(result);
 }
+<#
 
-
-C_word chicken_mq_recv(char *name, C_word oflags, int *rc)
-{
+(define chicken_mq_info (foreign-primitive scheme-object ((nonnull-c-string name) (s32vector rc))
+#<<EOF
     C_word result;
+#ifdef HAVE_POSIX_MQ
+    int ret;
+    *rc = 0;
+
+    struct mq_attr attr;
+
+    mqd_t queue = mq_open(name, O_RDONLY);
+
+    if (queue == -1) 
+    {
+      *rc = -1;
+      result = C_SCHEME_FALSE;
+    } else
+      {
+          int ret = mq_getattr(queue, &attr);
+          if (ret != 0) 
+          {
+              mq_close(queue);
+              *rc = ret;
+              result = C_SCHEME_FALSE;
+          }
+          else
+          {
+            C_word *a;
+            a = C_alloc (C_SIZEOF_LIST(3));
+            result = C_list(&a, 3, C_fix(attr.mq_maxmsg), C_fix(attr.mq_msgsize), C_fix(attr.mq_curmsgs));
+
+            mq_close(queue);
+          }
+       }
+        
+#else
+    result = C_SCHEME_FALSE;
+#endif
+    C_return(result);
+EOF
+))
+
+
+(define chicken_mq_recv (foreign-primitive scheme-object ((nonnull-c-string name) (scheme-object oflags) (s32vector rc))  
+#<<EOF
+ C_word result;
 #ifdef HAVE_POSIX_MQ
     int ret;
     *rc = 0;
 
     int flags = 0;
     flags = convert_flag_list(oflags);
-
     struct mq_attr attr;
-
     mqd_t queue = mq_open(name, O_RDONLY | flags);
-
     if (queue == -1) 
     {
       *rc = -1;
@@ -262,50 +301,6 @@ C_word chicken_mq_recv(char *name, C_word oflags, int *rc)
     result = C_SCHEME_FALSE;
 #endif
     C_return(result);
-}
-
-
-
-<#
-
-(define chicken_mq_info (foreign-primitive scheme-object ((nonnull-c-string name) (s32vector rc))
-#<<EOF
-    C_word result;
-#ifdef HAVE_POSIX_MQ
-    int ret;
-    *rc = 0;
-
-    struct mq_attr attr;
-
-    mqd_t queue = mq_open(name, O_RDONLY);
-
-    if (queue == -1) 
-    {
-      *rc = -1;
-      result = C_SCHEME_FALSE;
-    } else
-      {
-          int ret = mq_getattr(queue, &attr);
-          if (ret != 0) 
-          {
-              mq_close(queue);
-              *rc = ret;
-              result = C_SCHEME_FALSE;
-          }
-          else
-          {
-            C_word *a;
-            a = C_alloc (C_SIZEOF_LIST(3));
-            result = C_list(&a, 3, C_fix(attr.mq_maxmsg), C_fix(attr.mq_msgsize), C_fix(attr.mq_curmsgs));
-
-            mq_close(queue);
-          }
-       }
-        
-#else
-    result = C_SCHEME_FALSE;
-#endif
-    C_return(result);
 EOF
 ))
 
@@ -330,7 +325,6 @@ EOF
 
 (define chicken_mq_open (foreign-safe-lambda scheme-object "chicken_mq_open" nonnull-c-string scheme-object int int int s32vector))
 (define chicken_mq_send (foreign-safe-lambda scheme-object "chicken_mq_send" nonnull-c-string scheme-object scheme-object int s32vector))
-(define chicken_mq_recv (foreign-safe-lambda scheme-object "chicken_mq_recv" nonnull-c-string scheme-object s32vector))
 (define chicken_mq_unlink (foreign-safe-lambda scheme-object "chicken_mq_unlink" nonnull-c-string s32vector))
 
 (define valid-open-flags (list open/rdonly open/rdwr open/creat open/excl open/nonblock))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,68 +1,57 @@
 (import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) (chicken blob) test posix-mq)
 
-; 
-; (print posix-mq?)
-; (let* ((str "Hello, world!")
-      ;  (path (sprintf "/mqtest~A" (pseudo-random-integer 100)))
-      ;  (fd (mq-create path  10 1000 oflags: (list open/rdwr)))
-      ;  (msg (string->blob str)))
-    ; (print (mq-info path)) ;; -> this makes test fail
-    ; (print "sending " msg)
-    ; (mq-send path msg)
-    ; (print "received " (mq-recv path))
-    ; (mq-unlink path)
-  ; )
-; 
+
+(print posix-mq?)
+(let* ((str "Hello, world!")
+			 (path (sprintf "/mqtest~A" (pseudo-random-integer 100)))
+			 (fd (mq-create path  10 1000 oflags: (list open/rdwr)))
+			 (msg (string->blob str)))
+	(print (mq-info path)) 
+	(print "sending " msg)
+	(mq-send path msg)
+	(print "received " (mq-recv path))
+	(mq-unlink path))
+ 
 
 (define msg "Hello, world!")
 (define encoded-msg (string->blob msg))
-(define *default-path* (sprintf "/mqtest~A" (pseudo-random-integer 100000000)))
+(define *default-path* (sprintf "/mqtest~A" (pseudo-random-integer 100)))
 
-(define create-path
-  (lambda (path) (mq-create path  10 1000 oflags: (list open/rdwr))))
-(define info-path
+(define (create-queue path)
+  (mq-create path  10 1000 oflags: (list open/rdwr)))
+(define info-queue
   (lambda (path) (mq-info path)))
-(define send-path
+(define send-to-queue
   (lambda (path) (mq-send path encoded-msg)))
-(define recv-path
+(define recv-from-queue
   (lambda (path) (blob->string(mq-recv path encoded-msg))))
-(define delete-path
+(define delete-queue
   (lambda (path) (mq-unlink path)))
 
-(define test-mq-recv?
-  (lambda (path) (
-	      (let (
-		    (fd (create-path path))
-		    (sd (send-path path))
-		    (id (info-path path))
-		    (decoded-msg (recv-path path))
-		    (dd (delete-path path))
-		    )
-		decoded-msg
-		))))
+(define (mq-recv-aux path)
+  (let ((fd (create-queue path))
+				(sd (send-to-queue path))
+				(id (info-queue path))
+				(decoded-msg (recv-from-queue path))
+				(dd (delete-queue path)))
+		decoded-msg))
 
 
-(define test-mq-info?
-  (lambda (path) (
-	      (let* (
-		    (fd [create-path path] )
-		    (sd [send-path path])
-        (id [info-path path]) 
-        )
-        (length id))
-		    )
-      id
-		))
+(define (mq-info-aux path)
+ (let ((fd [create-queue path])
+					 (sd [send-to-queue path])
+					 (id [info-queue path]))
+			 (length id)))
 
 
 (test-group "receive"
-  (test-assert "received message should be equal to sent msg"
-	(test-mq-recv? *default-path*) )
-  )
+  (test "received message should be equal to sent msg"
+				msg
+				(mq-recv-aux *default-path*)))
 
 (test-group "info"
-  (test-assert "holds three pairs"
-	 (test-mq-info? *default-path*)  ) )
+  (test "queue holds three pairs" 3
+	 (mq-info-aux *default-path*)))
 
 
 (test-exit)

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,18 +1,18 @@
 (import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) (chicken blob) test posix-mq)
 
-
-(print posix-mq?)
-(let* ((str "Hello, world!")
-       (path (sprintf "/mqtest~A" (pseudo-random-integer 100)))
-       (fd (mq-create path  10 1000 oflags: (list open/rdwr)))
-       (msg (string->blob str)))
-    (print (mq-info path)) ;; -> this makes test fail
-    (print "sending " msg)
-    (mq-send path msg)
-    (print "received " (mq-recv path))
-    (mq-unlink path)
-  )
-
+; 
+; (print posix-mq?)
+; (let* ((str "Hello, world!")
+      ;  (path (sprintf "/mqtest~A" (pseudo-random-integer 100)))
+      ;  (fd (mq-create path  10 1000 oflags: (list open/rdwr)))
+      ;  (msg (string->blob str)))
+    ; (print (mq-info path)) ;; -> this makes test fail
+    ; (print "sending " msg)
+    ; (mq-send path msg)
+    ; (print "received " (mq-recv path))
+    ; (mq-unlink path)
+  ; )
+; 
 
 (define msg "Hello, world!")
 (define encoded-msg (string->blob msg))
@@ -29,7 +29,7 @@
 (define delete-path
   (lambda (path) (mq-unlink path)))
 
-(define test-mq-recv-aux
+(define test-mq-recv?
   (lambda (path) (
 	      (let (
 		    (fd (create-path path))
@@ -39,19 +39,30 @@
 		    (dd (delete-path path))
 		    )
 		decoded-msg
-		)
-	      
-	      ) )
+		))))
 
+
+(define test-mq-info?
+  (lambda (path) (
+	      (let* (
+		    (fd [create-path path] )
+		    (sd [send-path path])
+        (id [info-path path]) 
+        )
+        (length id))
+		    )
+      id
+		))
+
+
+(test-group "receive"
+  (test-assert "received message should be equal to sent msg"
+	(test-mq-recv? *default-path*) )
   )
 
-(define test-mq-recv
-  (lambda () ((test-mq-recv-aux *default-path*))))
+(test-group "info"
+  (test-assert "holds three pairs"
+	 (test-mq-info? *default-path*)  ) )
 
-(test-group "mq-recv"
-  (test "received message should be equal to msg"
-	msg
-	(test-mq-recv) )
-  )
 
 (test-exit)

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -16,39 +16,42 @@
 
 (define msg "Hello, world!")
 (define encoded-msg (string->blob msg))
-(define path (sprintf "/mqtest~A" (pseudo-random-integer 100000000)))
+(define *default-path* (sprintf "/mqtest~A" (pseudo-random-integer 100000000)))
 
 (define create-path
-  (lambda () (mq-create path  10 1000 oflags: (list open/rdwr))))
+  (lambda (path) (mq-create path  10 1000 oflags: (list open/rdwr))))
 (define info-path
-  (lambda () (mq-info path)))
+  (lambda (path) (mq-info path)))
 (define send-path
-  (lambda () (mq-send path encoded-msg)))
+  (lambda (path) (mq-send path encoded-msg)))
 (define recv-path
-  (lambda () (blob->string(mq-recv path encoded-msg))))
+  (lambda (path) (blob->string(mq-recv path encoded-msg))))
 (define delete-path
-  (lambda () (mq-unlink path)))
+  (lambda (path) (mq-unlink path)))
 
-(define test-mq-rcv
-  (lambda () (
+(define test-mq-recv-aux
+  (lambda (path) (
 	      (let (
-		    (fd (create-path))
-		    (sd (send-path))
-		    (id  (info-path))
-		    (decoded-msg (recv-path))
-		    (dd (delete-path))
+		    (fd (create-path path))
+		    (sd (send-path path))
+		    (id (info-path path))
+		    (decoded-msg (recv-path path))
+		    (dd (delete-path path))
 		    )
-		(sprintf "~A" decoded-msg)
+		decoded-msg
 		)
 	      
-	      ))
+	      ) )
 
   )
+
+(define test-mq-recv
+  (lambda () ((test-mq-recv-aux *default-path*))))
 
 (test-group "mq-recv"
   (test "received message should be equal to msg"
 	msg
-	(test-mq-rcv) )
+	(test-mq-recv) )
   )
 
 (test-exit)

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,4 +1,4 @@
-(import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) (chicken blob) posix-mq)
+(import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) (chicken blob) test posix-mq)
 
 
 (print posix-mq?)
@@ -14,3 +14,41 @@
   )
 
 
+(define msg "Hello, world!")
+(define encoded-msg (string->blob msg))
+(define path (sprintf "/mqtest~A" (pseudo-random-integer 100000000)))
+
+(define create-path
+  (lambda () (mq-create path  10 1000 oflags: (list open/rdwr))))
+(define info-path
+  (lambda () (mq-info path)))
+(define send-path
+  (lambda () (mq-send path encoded-msg)))
+(define recv-path
+  (lambda () (blob->string(mq-recv path encoded-msg))))
+(define delete-path
+  (lambda () (mq-unlink path)))
+
+(define test-mq-rcv
+  (lambda () (
+	      (let (
+		    (fd (create-path))
+		    (sd (send-path))
+		    (id  (info-path))
+		    (decoded-msg (recv-path))
+		    (dd (delete-path))
+		    )
+		(sprintf "~A" decoded-msg)
+		)
+	      
+	      ))
+
+  )
+
+(test-group "mq-recv"
+  (test "received message should be equal to msg"
+	msg
+	(test-mq-rcv) )
+  )
+
+(test-exit)


### PR DESCRIPTION
Hello,
After you pushed the fix for #1, I saw yet another bug which 
was descending from `mq-recv`.  
`mq-recv` doesn't fetch the equivalent data from the queue  
 on which the message has been sent. 
The  message is being manipulated somehow on its way.
This is the relevant output of the test run. A broken agreement shows up.
```scheme
sending #${48656c6c6f2c20776f726c6421}    ;;this is "Hello world!"
received #${48656c6c6f2c20778056daf7f5}   ;;this is "Hello w["
```
The test should have accordingly  the output.
```scheme
sending #${48656c6c6f2c20776f726c6421}
received #${48656c6c6f2c20776f726c6421}
```

To solve the bug, I imitate the method that you used here #1. 
It seems to work. What is really going on there, I can't say. 
May be you have a better solution?

I have expanded the test file with more tests and procedures. 
They are not critically important however. 
I just wanted to easily manage the pieces (methods) of the library.


 